### PR TITLE
Fix the `referencing` property for referencable objects

### DIFF
--- a/repyda/base/data/__init__.py
+++ b/repyda/base/data/__init__.py
@@ -1,2 +1,3 @@
 from .data import Data
+from .address import Address
 from .idb_stream import IDBStream

--- a/repyda/base/data/address.py
+++ b/repyda/base/data/address.py
@@ -1,0 +1,95 @@
+from __future__ import annotations
+from typing import Optional, Generator, Any
+
+
+import idc
+import idautils
+import ida_bytes
+import ida_name
+import ida_kernwin
+
+from repyda.base.elements import Addressable, TreeType, \
+    Referenceable, Referencing, Xref, Nameable
+
+
+class Address(Addressable, Nameable, Referenceable, Referencing):
+    def __init__(self, ea: Optional[int] = None, name: Optional[str] = None):
+        if ea is None:
+            if name is not None:
+                ea = ida_name.get_name_ea(idc.BADADDR, name)
+            else:
+                ea = ida_kernwin.get_screen_ea()
+
+        if not Address.exists_at(ea):
+            raise ValueError(f'Bad address {hex(ea)}')
+
+        self._ea = ea
+
+    @property
+    def ea(self) -> int:
+        return self._ea
+
+    @property
+    def flags(self) -> int:
+        return idc.get_full_flags(self.ea)
+
+    @property
+    def size(self) -> int:
+        return idc.get_item_size(self.ea)
+    
+    @property
+    def name(self) -> str:
+        return ida_name.get_name(self.ea)
+
+    @name.setter
+    def name(self, value: Optional[str]):
+        if value is None:
+            value = ''
+
+        if value == self.name:
+            return
+
+        ida_name.set_name(self.ea, value, idc.SN_CHECK)
+
+    @name.deleter
+    def name(self):
+        self.name = None
+
+    @property
+    def is_auto_name(self) -> bool:
+        return ida_bytes.has_auto_name(self.flags)
+
+    @property
+    def is_user_defined_name(self) -> bool:
+        return ida_bytes.has_user_name(self.flags)
+
+    def _default_tree_type(self) -> TreeType:
+        return TreeType.Names
+
+    def _is_valid_tree_type(self, type: TreeType) -> bool:
+        return type == self._default_tree_type()
+
+    @property
+    def references(self) -> Generator[Xref, Xref, Xref]:
+        for xref in idautils.XrefsTo(self.ea):
+            yield Xref(xref)
+
+    @property
+    def all_references(self) -> Generator[Xref, Xref, Xref]:
+        for ea in range(self.ea, self.ea + self.size):
+            for xref in idautils.XrefsTo(ea):
+                yield Xref(xref)
+
+    @property
+    def referencing(self) -> Generator[Xref, Xref, Xref]:
+        for xref in idautils.XrefsFrom(self.ea):
+            yield Xref(xref)
+
+    def __eq__(self, other: Any) -> bool:
+        return self.ea == other.ea
+
+    def __str__(self) -> str:
+        return f'{hex(self.ea)}: {self.name}'
+
+    def __repr__(self) -> str:
+        return f'{hex(self.ea)}: {self.name}'

--- a/repyda/base/elements/addressable.py
+++ b/repyda/base/elements/addressable.py
@@ -40,9 +40,8 @@ class Color:
 
 class Addressable(ABC):
     @staticmethod
-    @abstractmethod
     def exists_at(ea: int) -> bool:
-        raise NotImplementedError
+        return not idc.is_unknown(ida_bytes.get_full_flags(ea))
 
     @staticmethod
     def at(ea: int) -> Optional[Addressable]:
@@ -60,7 +59,7 @@ class Addressable(ABC):
 
     @staticmethod
     def exact_at(ea: int) -> Optional[Addressable]:
-        from repyda.base.data import Data
+        from repyda.base.data import Data, Address
         from repyda.base.functions import Function, Block, Instruction
 
         if Instruction.exists_at(ea):
@@ -71,6 +70,8 @@ class Addressable(ABC):
             return Function(ea)
         elif Data.exists_at(ea):
             return Data(ea)
+        elif Address.exists_at(ea):
+            return Address(ea)
         else:
             raise ValueError(f'Nothing defined at {ea}')
 

--- a/repyda/base/functions/block.py
+++ b/repyda/base/functions/block.py
@@ -6,7 +6,7 @@ import idautils
 import ida_bytes
 import ida_kernwin
 
-from repyda.base.elements import Addressable, Commentable, Nameable, Referenceable, \
+from repyda.base.elements import Addressable, Commentable, Referenceable, \
     Referencing, MultipleSequenceable, Xref, XrefType
 
 if TYPE_CHECKING:
@@ -14,7 +14,7 @@ if TYPE_CHECKING:
     from repyda.base.functions.instruction import Instruction
 
 
-class Block(Addressable, Commentable, Nameable, Referenceable, Referencing, MultipleSequenceable):
+class Block(Addressable, Commentable, Referenceable, Referencing, MultipleSequenceable):
     @staticmethod
     def exists_at(ea: int) -> bool:
         return idc.is_code(ida_bytes.get_full_flags(ea))
@@ -74,26 +74,6 @@ class Block(Addressable, Commentable, Nameable, Referenceable, Referencing, Mult
 
     @repeatable_comment.deleter
     def repeatable_comment(self):
-        raise NotImplementedError
-
-    @property
-    def name(self) -> str:
-        raise NotImplementedError
-
-    @name.setter
-    def name(self, value: Optional[str]):
-        raise NotImplementedError
-
-    @name.deleter
-    def name(self):
-        raise NotImplementedError
-
-    @property
-    def is_auto_name(self) -> bool:
-        raise NotImplementedError
-
-    @property
-    def is_user_defined_name(self) -> bool:
         raise NotImplementedError
 
     @property


### PR DESCRIPTION
- Add `Address` objects for instances with not accurate address like:
```x86asm
lea     rax, data+2
````
- Remove `Nameable` inheritance for `Block`